### PR TITLE
Add basic auth to recorder HTTP API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5092,6 +5092,21 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -8235,6 +8250,14 @@
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
           "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
         }
+      }
+    },
+    "express-basic-auth": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/express-basic-auth/-/express-basic-auth-1.2.1.tgz",
+      "integrity": "sha512-L6YQ1wQ/mNjVLAmK3AG1RK6VkokA1BIY6wmiH304Xtt/cLTps40EusZsU1Uop+v9lTDPxdtzbFmdXfFO3KEnwA==",
+      "requires": {
+        "basic-auth": "^2.0.1"
       }
     },
     "extend": {

--- a/packages/capacity-repository/package-lock.json
+++ b/packages/capacity-repository/package-lock.json
@@ -835,6 +835,11 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",

--- a/packages/hsl-capacity-provider/package-lock.json
+++ b/packages/hsl-capacity-provider/package-lock.json
@@ -757,6 +757,11 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
+		"reflect-metadata": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+		},
 		"regexpp": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -925,6 +930,19 @@
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 			"dev": true
+		},
+		"tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"tsyringe": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.6.0.tgz",
+			"integrity": "sha512-BMQAZamSfEmIQzH8WJeRu1yZGQbPSDuI9g+yEiKZFIcO46GPZuMOC2d0b52cVBdw1d++06JnDSIIZvEnogMdAw==",
+			"requires": {
+				"tslib": "^1.9.3"
+			}
 		},
 		"type-check": {
 			"version": "0.4.0",

--- a/packages/hsl-graphql-client/package-lock.json
+++ b/packages/hsl-graphql-client/package-lock.json
@@ -770,6 +770,11 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
+		"reflect-metadata": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+		},
 		"regexpp": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -938,6 +943,19 @@
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 			"dev": true
+		},
+		"tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"tsyringe": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.6.0.tgz",
+			"integrity": "sha512-BMQAZamSfEmIQzH8WJeRu1yZGQbPSDuI9g+yEiKZFIcO46GPZuMOC2d0b52cVBdw1d++06JnDSIIZvEnogMdAw==",
+			"requires": {
+				"tslib": "^1.9.3"
+			}
 		},
 		"type-check": {
 			"version": "0.4.0",

--- a/packages/http-api/package-lock.json
+++ b/packages/http-api/package-lock.json
@@ -4,26 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@aapokiiso/fillarivahti-capacity-repository": {
-			"version": "1.12.1",
-			"resolved": "https://registry.npmjs.org/@aapokiiso/fillarivahti-capacity-repository/-/fillarivahti-capacity-repository-1.12.1.tgz",
-			"integrity": "sha512-of04eR8u3dNGJHvCY4a8K4cxxQknJWsH0EfayZyWPcMm6eLuBcA2g546t+JlDrnHWZUx0oRx6fxi/lIPBhywtg==",
-			"requires": {
-				"@aapokiiso/fillarivahti-orm": "^1.10.1",
-				"date-fns": "^2.23.0",
-				"date-fns-tz": "^1.1.6",
-				"sequelize": "^6.6.5"
-			}
-		},
-		"@aapokiiso/fillarivahti-orm": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@aapokiiso/fillarivahti-orm/-/fillarivahti-orm-1.10.1.tgz",
-			"integrity": "sha512-C5AowNesxuOK0E2aDjD1qMaUagofawjMr5fxWKdMIZOoOK+FTXU2Tq/dHwJaK7QMhPywkU5jzuUy8wQnZhhG+A==",
-			"requires": {
-				"mysql2": "^2.3.0",
-				"sequelize": "^6.6.5"
-			}
-		},
 		"@babel/code-frame": {
 			"version": "7.12.11",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -172,14 +152,6 @@
 			"integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
 			"dev": true
 		},
-		"@types/debug": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-			"integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-			"requires": {
-				"@types/ms": "*"
-			}
-		},
 		"@types/express": {
 			"version": "4.17.13",
 			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
@@ -209,15 +181,11 @@
 			"integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
 			"dev": true
 		},
-		"@types/ms": {
-			"version": "0.7.31",
-			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
-		},
 		"@types/node": {
 			"version": "16.9.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-			"integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="
+			"integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+			"dev": true
 		},
 		"@types/qs": {
 			"version": "6.9.7",
@@ -530,16 +498,6 @@
 				"which": "^2.0.1"
 			}
 		},
-		"date-fns": {
-			"version": "2.28.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
-			"integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
-		},
-		"date-fns-tz": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.2.2.tgz",
-			"integrity": "sha512-vWtn44eEqnLbkACb7T5G5gPgKR4nY8NkNMOCyoY49NsRGHrcDmY2aysCyzDeA+u+vcDBn/w6nQqEDyouRs4m8w=="
-		},
 		"debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -553,11 +511,6 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
-		},
-		"denque": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
-			"integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -577,11 +530,6 @@
 			"requires": {
 				"esutils": "^2.0.2"
 			}
-		},
-		"dottie": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
-			"integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
 		},
 		"ee-first": {
 			"version": "1.1.1",
@@ -941,14 +889,6 @@
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
 		},
-		"generate-function": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-			"integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-			"requires": {
-				"is-property": "^1.0.2"
-			}
-		},
 		"get-intrinsic": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -1057,11 +997,6 @@
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
 			"dev": true
 		},
-		"inflection": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.1.tgz",
-			"integrity": "sha512-dldYtl2WlN0QDkIDtg8+xFwOS2Tbmp12t1cHa5/YClU6ZQjTFm7B66UcVbh9NQB+HvT5BAd2t5+yKsBkw5pcqA=="
-		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1107,11 +1042,6 @@
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
-		},
-		"is-property": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
 		},
 		"is-stream": {
 			"version": "2.0.1",
@@ -1172,11 +1102,6 @@
 				"type-check": "~0.4.0"
 			}
 		},
-		"lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -1214,15 +1139,11 @@
 				}
 			}
 		},
-		"long": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-		},
 		"lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
 			"requires": {
 				"yallist": "^4.0.0"
 			}
@@ -1269,72 +1190,10 @@
 				"brace-expansion": "^1.1.7"
 			}
 		},
-		"moment": {
-			"version": "2.29.1",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-			"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
-		},
-		"moment-timezone": {
-			"version": "0.5.34",
-			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.34.tgz",
-			"integrity": "sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==",
-			"requires": {
-				"moment": ">= 2.9.0"
-			}
-		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-		},
-		"mysql2": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.3.3.tgz",
-			"integrity": "sha512-wxJUev6LgMSgACDkb/InIFxDprRa6T95+VEoR+xPvtngtccNH2dGjEB/fVZ8yg1gWv1510c9CvXuJHi5zUm0ZA==",
-			"requires": {
-				"denque": "^2.0.1",
-				"generate-function": "^2.3.1",
-				"iconv-lite": "^0.6.3",
-				"long": "^4.0.0",
-				"lru-cache": "^6.0.0",
-				"named-placeholders": "^1.1.2",
-				"seq-queue": "^0.0.5",
-				"sqlstring": "^2.3.2"
-			},
-			"dependencies": {
-				"iconv-lite": {
-					"version": "0.6.3",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-					"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3.0.0"
-					}
-				}
-			}
-		},
-		"named-placeholders": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.2.tgz",
-			"integrity": "sha512-wiFWqxoLL3PGVReSZpjLVxyJ1bRqe+KKJVbr4hGs1KWfTZTQyezHFBbuKj9hsizHyGV2ne7EMjHdxEGAybD5SA==",
-			"requires": {
-				"lru-cache": "^4.1.3"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "4.1.5",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-				}
-			}
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -1427,11 +1286,6 @@
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
 			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 		},
-		"pg-connection-string": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-			"integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
-		},
 		"prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -1457,11 +1311,6 @@
 				"forwarded": "0.2.0",
 				"ipaddr.js": "1.9.1"
 			}
-		},
-		"pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"punycode": {
 			"version": "2.1.1",
@@ -1526,11 +1375,6 @@
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true
 		},
-		"retry-as-promised": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-5.0.0.tgz",
-			"integrity": "sha512-6S+5LvtTl2ggBumk04hBo/4Uf6fRJUwIgunGZ7CYEBCeufGFW1Pu6ucUf/UskHeWOIsUcLOGLFXPig5tR5V1nA=="
-		},
 		"rimraf": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -1554,6 +1398,7 @@
 			"version": "7.3.5",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
 			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"dev": true,
 			"requires": {
 				"lru-cache": "^6.0.0"
 			}
@@ -1584,53 +1429,6 @@
 					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
 			}
-		},
-		"seq-queue": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
-			"integrity": "sha1-1WgS4cAXpuTnw+Ojeh2m143TyT4="
-		},
-		"sequelize": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.13.0.tgz",
-			"integrity": "sha512-p0dXXGZSc0Ng7CdGwlKN4P6DTRD/w9Ar2CnmHamNVDnqEWh6pMVOp3xrlG5+IWhbwrqL3SjIYEYt3Xog1vXRDw==",
-			"requires": {
-				"@types/debug": "^4.1.7",
-				"debug": "^4.3.3",
-				"dottie": "^2.0.2",
-				"inflection": "^1.13.1",
-				"lodash": "^4.17.21",
-				"moment": "^2.29.1",
-				"moment-timezone": "^0.5.34",
-				"pg-connection-string": "^2.5.0",
-				"retry-as-promised": "^5.0.0",
-				"semver": "^7.3.5",
-				"sequelize-pool": "^7.1.0",
-				"toposort-class": "^1.0.1",
-				"uuid": "^8.3.2",
-				"validator": "^13.7.0",
-				"wkx": "^0.5.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.3",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				}
-			}
-		},
-		"sequelize-pool": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-7.1.0.tgz",
-			"integrity": "sha512-G9c0qlIWQSK29pR/5U2JF5dDQeqqHRragoyahj/Nx4KOOQ3CPPfzxnfqFPCSB7x5UgjOgnZ61nSxz+fjDpRlJg=="
 		},
 		"serve-static": {
 			"version": "1.14.1",
@@ -1723,11 +1521,6 @@
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
-		},
-		"sqlstring": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.2.tgz",
-			"integrity": "sha512-vF4ZbYdKS8OnoJAWBmMxCQDkiEBkGQYU7UZPtL8flbDRSNkhaXvRJ279ZtI6M+zDaQovVU4tuRgzK5fVhvFAhg=="
 		},
 		"stack-trace": {
 			"version": "0.0.10",
@@ -1839,11 +1632,6 @@
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
 		},
-		"toposort-class": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
-			"integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg="
-		},
 		"triple-beam": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
@@ -1916,21 +1704,11 @@
 			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
 			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
-		"uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-		},
 		"v8-compile-cache": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
-		},
-		"validator": {
-			"version": "13.7.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-			"integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
 		},
 		"vary": {
 			"version": "1.1.2",
@@ -1995,14 +1773,6 @@
 				}
 			}
 		},
-		"wkx": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
-			"integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -2018,7 +1788,8 @@
 		"yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		}
 	}
 }

--- a/packages/orm-open-data-parser/package-lock.json
+++ b/packages/orm-open-data-parser/package-lock.json
@@ -1,0 +1,89 @@
+{
+	"name": "@aapokiiso/fillarivahti-orm-open-data-parser",
+	"version": "1.12.1",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@fast-csv/format": {
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+			"integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+			"requires": {
+				"@types/node": "^14.0.1",
+				"lodash.escaperegexp": "^4.1.2",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isequal": "^4.5.0",
+				"lodash.isfunction": "^3.0.9",
+				"lodash.isnil": "^4.0.0"
+			}
+		},
+		"@fast-csv/parse": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.6.tgz",
+			"integrity": "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==",
+			"requires": {
+				"@types/node": "^14.0.1",
+				"lodash.escaperegexp": "^4.1.2",
+				"lodash.groupby": "^4.6.0",
+				"lodash.isfunction": "^3.0.9",
+				"lodash.isnil": "^4.0.0",
+				"lodash.isundefined": "^3.0.1",
+				"lodash.uniq": "^4.5.0"
+			}
+		},
+		"@types/node": {
+			"version": "14.17.17",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.17.tgz",
+			"integrity": "sha512-niAjcewgEYvSPCZm3OaM9y6YQrL2SEPH9PymtE6fuZAvFiP6ereCcvApGl2jKTq7copTIguX3PBvfP08LN4LvQ=="
+		},
+		"fast-csv": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
+			"integrity": "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==",
+			"requires": {
+				"@fast-csv/format": "4.3.5",
+				"@fast-csv/parse": "4.3.6"
+			}
+		},
+		"lodash.escaperegexp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+			"integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
+		},
+		"lodash.groupby": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+			"integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E="
+		},
+		"lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+		},
+		"lodash.isfunction": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+			"integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
+		},
+		"lodash.isnil": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+			"integrity": "sha1-SeKM1VkBNFjIFMVHnTxmOiG/qmw="
+		},
+		"lodash.isundefined": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+			"integrity": "sha1-I+89lTVWUgOmbO/VuDD4SJEa+0g="
+		},
+		"lodash.uniq": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+		}
+	}
+}

--- a/packages/orm/package-lock.json
+++ b/packages/orm/package-lock.json
@@ -900,6 +900,11 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
+		"reflect-metadata": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+		},
 		"regexpp": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -1120,6 +1125,19 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
 			"integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg="
+		},
+		"tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"tsyringe": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.6.0.tgz",
+			"integrity": "sha512-BMQAZamSfEmIQzH8WJeRu1yZGQbPSDuI9g+yEiKZFIcO46GPZuMOC2d0b52cVBdw1d++06JnDSIIZvEnogMdAw==",
+			"requires": {
+				"tslib": "^1.9.3"
+			}
 		},
 		"type-check": {
 			"version": "0.4.0",

--- a/packages/recorder-http-api/package-lock.json
+++ b/packages/recorder-http-api/package-lock.json
@@ -294,6 +294,14 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
+		"basic-auth": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+			"requires": {
+				"safe-buffer": "5.1.2"
+			}
+		},
 		"body-parser": {
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -788,6 +796,14 @@
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
 					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
 				}
+			}
+		},
+		"express-basic-auth": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/express-basic-auth/-/express-basic-auth-1.2.1.tgz",
+			"integrity": "sha512-L6YQ1wQ/mNjVLAmK3AG1RK6VkokA1BIY6wmiH304Xtt/cLTps40EusZsU1Uop+v9lTDPxdtzbFmdXfFO3KEnwA==",
+			"requires": {
+				"basic-auth": "^2.0.1"
 			}
 		},
 		"fast-deep-equal": {

--- a/packages/recorder-http-api/package.json
+++ b/packages/recorder-http-api/package.json
@@ -30,6 +30,7 @@
     "@aapokiiso/fillarivahti-orm": "^1.10.1",
     "cors": "^2.8.5",
     "express": "^4.17.1",
+    "express-basic-auth": "^1.2.1",
     "http-status-codes": "^2.1.4",
     "qs": "^6.10.1",
     "reflect-metadata": "^0.1.13",

--- a/packages/recorder-http-api/src/app.ts
+++ b/packages/recorder-http-api/src/app.ts
@@ -1,81 +1,15 @@
-import { container } from 'tsyringe';
 import express from 'express';
-import { StatusCodes } from 'http-status-codes';
-import { Logger } from 'winston';
+import healthcheckRouter from './controller/healthcheck';
+import recordRouter from './controller/record';
+import shredRouter from './controller/shred';
 import cors from 'cors';
-import * as FillarivahtiOrm from '@aapokiiso/fillarivahti-orm';
-import * as FillarivahtiHslCapacityProvider from '@aapokiiso/fillarivahti-hsl-capacity-provider';
-import * as FillarivahtiCapacityRepository from '@aapokiiso/fillarivahti-capacity-repository';
-
-const ormConnectionProvider = container.resolve<FillarivahtiOrm.ConnectionProvider>('FillarivahtiOrm.ConnectionProvider');
-const capacityProvider = container.resolve<FillarivahtiHslCapacityProvider.CapacityProvider>('FillarivahtiHslCapacityProvider.CapacityProvider');
-const capacityRepository = container.resolve<FillarivahtiCapacityRepository.CapacityRepository>('FillarivahtiCapacityRepository.CapacityRepository');
-const capacityShredder = container.resolve<FillarivahtiCapacityRepository.CapacityShredder>('FillarivahtiCapacityRepository.CapacityShredder');
-const logger = container.resolve<Logger>('FillarivahtiRecorderHttpApi.Logger');
 
 const app = express();
 
 app.use(cors());
 
-app.get('/', async (req, res) => {
-    try {
-        const conn = await ormConnectionProvider.getConnection();
-        await conn.authenticate();
-
-        return res.status(StatusCodes.OK).end();
-    } catch (error: any) {
-        logger.error('Failed to connect to the database in the healthcheck endpoint.', {
-            error: error.message,
-            stack: error.stack,
-        });
-
-        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
-    }
-});
-
-app.post('/record', async (req, res) => {
-    logger.info('Fillarivahti recorder recording is run.');
-
-    try {
-        const capacities = await capacityProvider.getCapacities();
-
-        await capacityRepository.createMany(capacities);
-
-        logger.info('Fillarivahti recorder recording is completed.');
-
-        return res.status(StatusCodes.OK).end();
-    } catch (error: any) {
-        logger.error('Failed to record bike station capacities.', {
-            error: error.message,
-            stack: error.stack,
-        });
-
-        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
-    }
-});
-
-app.post('/shred', async (req, res) => {
-    logger.info('Fillarivahti recorder shredding is run.');
-
-    // TODO: move to configuration
-    // Capacity records are retained for 5 full weeks (5 * 7 = 35), ie. the
-    // current week and 4 weeks prior.
-    const olderThanDays = 35;
-
-    try {
-        await capacityShredder.shredByAge(olderThanDays);
-
-        logger.info('Fillarivahti recorder shredding is completed.');
-
-        return res.status(StatusCodes.OK).end();
-    } catch (error: any) {
-        logger.error('Failed to shred old bike station capacities.', {
-            error: error.message,
-            stack: error.stack,
-        });
-
-        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
-    }
-});
+app.use('/', healthcheckRouter);
+app.use('/record', recordRouter);
+app.use('/shred', shredRouter);
 
 export default app;

--- a/packages/recorder-http-api/src/controller/healthcheck.ts
+++ b/packages/recorder-http-api/src/controller/healthcheck.ts
@@ -1,0 +1,30 @@
+import { container } from 'tsyringe';
+import * as FillarivahtiOrm from '@aapokiiso/fillarivahti-orm';
+import { Logger } from 'winston';
+
+const ormConnectionProvider = container.resolve<FillarivahtiOrm.ConnectionProvider>('FillarivahtiOrm.ConnectionProvider');
+const logger = container.resolve<Logger>('FillarivahtiRecorderHttpApi.Logger');
+
+import * as express from 'express';
+import { StatusCodes } from 'http-status-codes';
+
+// eslint-disable-next-line new-cap
+const healthcheckRouter = express.Router();
+
+healthcheckRouter.get('/', async (req, res) => {
+    try {
+        const conn = await ormConnectionProvider.getConnection();
+        await conn.authenticate();
+
+        return res.status(StatusCodes.OK).end();
+    } catch (error: any) {
+        logger.error('Failed to connect to the database in the healthcheck endpoint.', {
+            error: error.message,
+            stack: error.stack,
+        });
+
+        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+    }
+});
+
+export default healthcheckRouter;

--- a/packages/recorder-http-api/src/controller/record.ts
+++ b/packages/recorder-http-api/src/controller/record.ts
@@ -1,0 +1,39 @@
+import { container } from 'tsyringe';
+import express from 'express';
+import { StatusCodes } from 'http-status-codes';
+import { Logger } from 'winston';
+import * as FillarivahtiHslCapacityProvider from '@aapokiiso/fillarivahti-hsl-capacity-provider';
+import * as FillarivahtiCapacityRepository from '@aapokiiso/fillarivahti-capacity-repository';
+import { middleware as basicAuthMiddleware } from '../middleware/basic-auth';
+
+const capacityProvider = container.resolve<FillarivahtiHslCapacityProvider.CapacityProvider>('FillarivahtiHslCapacityProvider.CapacityProvider');
+const capacityRepository = container.resolve<FillarivahtiCapacityRepository.CapacityRepository>('FillarivahtiCapacityRepository.CapacityRepository');
+const logger = container.resolve<Logger>('FillarivahtiRecorderHttpApi.Logger');
+
+// eslint-disable-next-line new-cap
+const recordRouter = express.Router();
+
+recordRouter.use(basicAuthMiddleware);
+
+recordRouter.post('/', async (req, res) => {
+    logger.info('Fillarivahti recorder recording is run.');
+
+    try {
+        const capacities = await capacityProvider.getCapacities();
+
+        await capacityRepository.createMany(capacities);
+
+        logger.info('Fillarivahti recorder recording is completed.');
+
+        return res.status(StatusCodes.OK).end();
+    } catch (error: any) {
+        logger.error('Failed to record bike station capacities.', {
+            error: error.message,
+            stack: error.stack,
+        });
+
+        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+    }
+});
+
+export default recordRouter;

--- a/packages/recorder-http-api/src/controller/shred.ts
+++ b/packages/recorder-http-api/src/controller/shred.ts
@@ -1,0 +1,40 @@
+import { container } from 'tsyringe';
+import express from 'express';
+import { StatusCodes } from 'http-status-codes';
+import { Logger } from 'winston';
+import * as FillarivahtiCapacityRepository from '@aapokiiso/fillarivahti-capacity-repository';
+import { middleware as basicAuthMiddleware } from '../middleware/basic-auth';
+
+const capacityShredder = container.resolve<FillarivahtiCapacityRepository.CapacityShredder>('FillarivahtiCapacityRepository.CapacityShredder');
+const logger = container.resolve<Logger>('FillarivahtiRecorderHttpApi.Logger');
+
+// eslint-disable-next-line new-cap
+const shredRouter = express.Router();
+
+shredRouter.use(basicAuthMiddleware);
+
+shredRouter.post('/', async (req, res) => {
+    logger.info('Fillarivahti recorder shredding is run.');
+
+    // TODO: move to configuration
+    // Capacity records are retained for 5 full weeks (5 * 7 = 35), ie. the
+    // current week and 4 weeks prior.
+    const olderThanDays = 35;
+
+    try {
+        await capacityShredder.shredByAge(olderThanDays);
+
+        logger.info('Fillarivahti recorder shredding is completed.');
+
+        return res.status(StatusCodes.OK).end();
+    } catch (error: any) {
+        logger.error('Failed to shred old bike station capacities.', {
+            error: error.message,
+            stack: error.stack,
+        });
+
+        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+    }
+});
+
+export default shredRouter;

--- a/packages/recorder-http-api/src/di.ts
+++ b/packages/recorder-http-api/src/di.ts
@@ -7,9 +7,12 @@ import * as FillarivahtiHslCapacityProvider from '@aapokiiso/fillarivahti-hsl-ca
 
 import { Logger } from 'winston';
 import { jsonLogger } from './util/json-logger';
+import { Configuration } from './interface/Configuration';
+import { EnvConfiguration } from './service/EnvConfiguration';
 
 FillarivahtiOrm.diRegisterDefaults();
 FillarivahtiCapacityRepository.diRegisterDefaults();
 FillarivahtiHslCapacityProvider.diRegisterDefaults();
 
+container.register<Configuration>('FillarivahtiRecorderHttpApi.Configuration', { useClass: EnvConfiguration });
 container.register<Logger>('FillarivahtiRecorderHttpApi.Logger', { useValue: jsonLogger });

--- a/packages/recorder-http-api/src/interface/Configuration.ts
+++ b/packages/recorder-http-api/src/interface/Configuration.ts
@@ -1,0 +1,4 @@
+export interface Configuration {
+    getBasicAuthUsername(): string | undefined;
+    getBasicAuthPassword(): string | undefined;
+}

--- a/packages/recorder-http-api/src/middleware/basic-auth.ts
+++ b/packages/recorder-http-api/src/middleware/basic-auth.ts
@@ -1,0 +1,22 @@
+import * as express from 'express';
+import * as basicAuth from 'express-basic-auth';
+import { container } from 'tsyringe';
+import { Configuration } from '../interface/Configuration';
+
+const configuration = container.resolve<Configuration>('FillarivahtiRecorderHttpApi.Configuration');
+
+export const middleware = (req: express.Request, res: express.Response, next: express.NextFunction): void => {
+    const username = configuration.getBasicAuthUsername();
+    const password = configuration.getBasicAuthPassword();
+
+    if (username && password) {
+        basicAuth.default({
+            users: {
+                [username]: password,
+            },
+        })(req, res, next);
+    } else {
+        // eslint-disable-next-line callback-return
+        next();
+    }
+};

--- a/packages/recorder-http-api/src/service/EnvConfiguration.ts
+++ b/packages/recorder-http-api/src/service/EnvConfiguration.ts
@@ -1,0 +1,13 @@
+import { singleton } from 'tsyringe';
+import { Configuration } from '../interface/Configuration';
+
+@singleton()
+export class EnvConfiguration implements Configuration {
+    getBasicAuthUsername(): string | undefined {
+        return process.env.BASIC_AUTH_USERNAME;
+    }
+
+    getBasicAuthPassword(): string | undefined {
+        return process.env.BASIC_AUTH_PASSWORD;
+    }
+}


### PR DESCRIPTION
Additionally, Express routes are split to separate controllers. This makes it possible to have basic auth when recording and shredding, but not to have it on the healthcheck endpoint.